### PR TITLE
deprecate old csi API endpoints

### DIFF
--- a/charts/latest/spdk-csi/values.yaml
+++ b/charts/latest/spdk-csi/values.yaml
@@ -7,7 +7,7 @@ driverName: csi.spdk.io
 image:
   spdkcsi:
     repository: simplyblock/spdkcsi
-    tag: latest
+    tag: pr-43
     pullPolicy: Always
   csiProvisioner:
     repository: registry.k8s.io/sig-storage/csi-provisioner

--- a/charts/latest/spdk-csi/values.yaml
+++ b/charts/latest/spdk-csi/values.yaml
@@ -7,7 +7,7 @@ driverName: csi.spdk.io
 image:
   spdkcsi:
     repository: simplyblock/spdkcsi
-    tag: pr-43
+    tag: latest
     pullPolicy: Always
   csiProvisioner:
     repository: registry.k8s.io/sig-storage/csi-provisioner

--- a/pkg/util/jsonrpc.go
+++ b/pkg/util/jsonrpc.go
@@ -178,7 +178,7 @@ func (client *RPCClient) info() string {
 func (client *RPCClient) lvStores() ([]LvStore, error) {
 	var result []CSIPoolsResp
 
-	out, err := client.CallSBCLI("GET", "csi/get_pools", nil)
+	out, err := client.CallSBCLI("GET", "/pool/get_pools", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (client *RPCClient) createVolume(params *CreateLVolData) (string, error) {
 // get a volume and return a BDev,, lvsName/lvolName
 func (client *RPCClient) getVolume(lvolID string) (*BDev, error) {
 	var result []BDev
-	out, err := client.CallSBCLI("GET", "csi/get_volume_info/"+lvolID, nil)
+	out, err := client.CallSBCLI("GET", "/lvol/"+lvolID, nil)
 	if err != nil {
 		if errorMatches(err, ErrJSONNoSuchDevice) {
 			err = ErrJSONNoSuchDevice
@@ -297,7 +297,7 @@ func (client *RPCClient) getVolumeInfo(lvolID string) (map[string]string, error)
 }
 
 func (client *RPCClient) deleteVolume(lvolID string) error {
-	_, err := client.CallSBCLI("DELETE", "csi/delete_lvol/"+lvolID, nil)
+	_, err := client.CallSBCLI("DELETE", "/lvol/"+lvolID, nil)
 	if errorMatches(err, ErrJSONNoSuchDevice) {
 		err = ErrJSONNoSuchDevice // may happen in concurrency
 	}
@@ -311,7 +311,7 @@ func (client *RPCClient) resizeVolume(lvolID string, newSize int64) (bool, error
 		NewSize: newSize,
 	}
 	var result bool
-	out, err := client.CallSBCLI("POST", "csi/resize_lvol", &params)
+	out, err := client.CallSBCLI("POST", "/lvol/resize/"+lvolID, &params)
 	if err != nil {
 		return false, err
 	}
@@ -325,7 +325,7 @@ func (client *RPCClient) resizeVolume(lvolID string, newSize int64) (bool, error
 func (client *RPCClient) listSnapshots() ([]*SnapshotResp, error) {
 	var results []*SnapshotResp
 
-	out, err := client.CallSBCLI("GET", "csi/list_snapshots", nil)
+	out, err := client.CallSBCLI("GET", "/snapshot", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +337,7 @@ func (client *RPCClient) listSnapshots() ([]*SnapshotResp, error) {
 }
 
 func (client *RPCClient) deleteSnapshot(snapshotID string) error {
-	_, err := client.CallSBCLI("DELETE", "csi/delete_snapshot/%s"+snapshotID, nil)
+	_, err := client.CallSBCLI("DELETE", "/snapshot/%s"+snapshotID, nil)
 
 	if errorMatches(err, ErrJSONNoSuchDevice) {
 		err = ErrJSONNoSuchDevice // may happen in concurrency
@@ -357,7 +357,7 @@ func (client *RPCClient) snapshot(lvolID, snapShotName, poolName string) (string
 		PoolName:     poolName,
 	}
 	var snapshotID string
-	out, err := client.CallSBCLI("POST", "csi/create_snapshot", &params)
+	out, err := client.CallSBCLI("POST", "/snapshot", &params)
 	snapshotID, ok := out.(string)
 	if !ok {
 		return "", fmt.Errorf("failed to convert the response to []ResizeVolResp type. Interface: %v", out)

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -152,7 +152,7 @@ func (node *NodeNVMf) DeleteSnapshot(snapshotID string) error {
 
 // PublishVolume exports a volume through NVMf target
 func (node *NodeNVMf) PublishVolume(lvolID string) error {
-	_, err := node.client.CallSBCLI("GET", "csi/publish_volume/"+lvolID, nil)
+	_, err := node.client.CallSBCLI("GET", "/lvol/publish_volume/"+lvolID, nil)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (node *NodeNVMf) PublishVolume(lvolID string) error {
 
 // UnpublishVolume unexports a volume through NVMf target
 func (node *NodeNVMf) UnpublishVolume(lvolID string) error {
-	_, err := node.client.CallSBCLI("GET", "csi/unpublish_volume/"+lvolID, nil)
+	_, err := node.client.CallSBCLI("GET", "/lvol/unpublish_volume/"+lvolID, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -156,6 +156,7 @@ func (node *NodeNVMf) PublishVolume(lvolID string) error {
 	if err != nil {
 		return err
 	}
+
 	klog.V(5).Infof("volume published: %s", lvolID)
 	return nil
 }

--- a/pkg/util/nvmf.go
+++ b/pkg/util/nvmf.go
@@ -156,7 +156,6 @@ func (node *NodeNVMf) PublishVolume(lvolID string) error {
 	if err != nil {
 		return err
 	}
-
 	klog.V(5).Infof("volume published: %s", lvolID)
 	return nil
 }


### PR DESCRIPTION
Tested the changes by running e2e tests.

```
Will run 5 of 5 specs
------------------------------
• [SLOW TEST] [61.578 seconds]
CSI Driver tests Control Plane: delete second lvol while the first lvol has IO running if a node has lvol with IO running, adding and deleting an new lvol from the same node should work
/home/ubuntu/actions-runner/_work/simplyBlockDeploy/simplyBlockDeploy/spdk-csi/e2e/controlplane.go:26
------------------------------
•
------------------------------
• [SLOW TEST] [50.774 seconds]
SPDKCSI-NVMEOF Test SPDK CSI Dynamic Volume Provisioning Test the flow for Dynamic volume provisioning
/home/ubuntu/actions-runner/_work/simplyBlockDeploy/simplyBlockDeploy/spdk-csi/e2e/nvmeof.go:30
------------------------------
• [SLOW TEST] [122.170 seconds]
SPDKCSI-NVMEOF Test SPDK CSI Dynamic Volume Provisioning Test the flow for Caching nodes
/home/ubuntu/actions-runner/_work/simplyBlockDeploy/simplyBlockDeploy/spdk-csi/e2e/nvmeof.go:51
------------------------------
• [SLOW TEST] [80.269 seconds]
SPDKCSI-NVMEOF Test SPDK CSI Dynamic Volume Provisioning Test multiple PVCs
/home/ubuntu/actions-runner/_work/simplyBlockDeploy/simplyBlockDeploy/spdk-csi/e2e/nvmeof.go:79
------------------------------

Ran 5 of 5 Specs in 315.185 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (315.19s)
PASS
ok  	github.com/spdk/spdk-csi/e2e	316.544s
```