### PR TITLE
added daemonset for reserve storage-node

### DIFF
--- a/charts/latest/spdk-csi/templates/caching-node-handler.yaml
+++ b/charts/latest/spdk-csi/templates/caching-node-handler.yaml
@@ -24,7 +24,8 @@ spec:
       serviceAccountName: caching-node-service-account
       containers:
       - name: caching-node-handler
-        image: simplyblock/caching-node-handler
+        image: "{{ .Values.image.cachingNode.repository }}:{{ .Values.image.cachingNode.tag }}"
+        imagePullPolicy: "Always"
         env:
         - name: SPDKCSI_SECRET
           valueFrom:

--- a/charts/latest/spdk-csi/templates/caching-node-handler.yaml
+++ b/charts/latest/spdk-csi/templates/caching-node-handler.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       - name: caching-node-handler
         image: "{{ .Values.image.cachingNode.repository }}:{{ .Values.image.cachingNode.tag }}"
-        imagePullPolicy: "Always"
+        imagePullPolicy: "{{ .Values.image.cachingNode.pullPolicy }}"
         env:
         - name: SPDKCSI_SECRET
           valueFrom:

--- a/charts/latest/spdk-csi/templates/caching-node.yaml
+++ b/charts/latest/spdk-csi/templates/caching-node.yaml
@@ -65,7 +65,7 @@ spec:
       containers:
       - name: c-node-api-container
         image: "{{ .Values.image.simplyblock.repository }}:{{ .Values.image.simplyblock.tag }}"
-        imagePullPolicy: "Always"
+        imagePullPolicy: "{{ .Values.image.simplyblock.pullPolicy }}"
         command: ["python", "simplyblock_web/caching_node_app_k8s.py"]
         env:
         - name: HOSTNAME

--- a/charts/latest/spdk-csi/templates/config-map.yaml
+++ b/charts/latest/spdk-csi/templates/config-map.yaml
@@ -167,8 +167,8 @@ data:
     # Load environment variables
     action_type = os.getenv("ACTION_TYPE")
     uuid = os.getenv("SNODE_UUID", "")
-    distr_ndcs = int(os.getenv("DISTR_NDCS", 1))
-    distr_npcs = int(os.getenv("DISTR_NPCS", 1))
+    distr_ndcs = int(os.getenv("DISTR_NDCS", 1)) if os.getenv("DISTR_NDCS", "").isdigit() else 1
+    distr_npcs = int(os.getenv("DISTR_NPCS", 1)) if os.getenv("DISTR_NPCS", "").isdigit() else 1
 
     secret = json.loads(os.getenv("SPDKCSI_SECRET"))
     cluster_secret = secret['simplybk']['secret']

--- a/charts/latest/spdk-csi/templates/config-map.yaml
+++ b/charts/latest/spdk-csi/templates/config-map.yaml
@@ -133,14 +133,14 @@ data:
             print(f"Error occurred while getting node statuses: {e}")
         return []
 
-    def activate_cluster_if_needed(cluster_ip, cluster_uuid, cluster_secret):
+    def activate_cluster_if_needed(cluster_ip, cluster_uuid, cluster_secret, distr_ndcs, distr_npcs):
         retries = 60
-
+        total_value = distr_ndcs + distr_npcs + 1
         while retries > 0:
             node_statuses = get_node_statuses(cluster_ip, cluster_uuid, cluster_secret)
             online_nodes = [node for node in node_statuses if node.get('status') == 'online']
 
-            if len(online_nodes) >= 3:
+            if len(online_nodes) >= total_value:
                 print("Proceeding with cluster activation.")
                 url = f"{cluster_ip}/cluster/activate/{cluster_uuid}"
                 headers = {
@@ -162,11 +162,14 @@ data:
             print(f"Not enough 'online' nodes. Retrying in 5 seconds... Remaining retries: {retries}")
             sleep(5)
 
-        print("Cluster not activated: Number of 'online' storage nodes is less than 3 after maximum retries.")
+        print(f"Cluster not activated: Number of 'online' storage nodes is less than {total_value} after maximum retries.")
 
     # Load environment variables
     action_type = os.getenv("ACTION_TYPE")
     uuid = os.getenv("SNODE_UUID", "")
+    distr_ndcs = int(os.getenv("DISTR_NDCS", 1))
+    distr_npcs = int(os.getenv("DISTR_NPCS", 1))
+
     secret = json.loads(os.getenv("SPDKCSI_SECRET"))
     cluster_secret = secret['simplybk']['secret']
 
@@ -182,7 +185,7 @@ data:
     # Check the action type and perform the appropriate action
     if action_type == "cl_activate":
         # Check if we should activate the cluster
-        activate_cluster_if_needed(cluster_ip, cluster_uuid, cluster_secret)
+        activate_cluster_if_needed(cluster_ip, cluster_uuid, cluster_secret, distr_ndcs, distr_npcs)
     elif action_type in ["sn_restart", "sn_shutdown", "sn_remove"] and uuid:
         if action_type == "sn_restart":
             url = f"{cluster_ip}/storagenode/restart/{uuid}"

--- a/charts/latest/spdk-csi/templates/job.yaml
+++ b/charts/latest/spdk-csi/templates/job.yaml
@@ -31,10 +31,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: DISTR_NDCS
+          value: "{{ .Values.logicalVolume.distr_ndcs }}"
+        - name: DISTR_NPCS
+          value: "{{ .Values.logicalVolume.distr_npcs }}"  
         - name: ACTION_TYPE
           value: "cl_activate" #options: "sn_idle", "sn_restart", "sn_shutdown", "sn_remove", "cl_activate"
         - name: SNODE_UUID
-          value: ""
+          value: "" 
         volumeMounts:
             - name: script-config
               mountPath: /config

--- a/charts/latest/spdk-csi/templates/storage-node-handler.yaml
+++ b/charts/latest/spdk-csi/templates/storage-node-handler.yaml
@@ -24,7 +24,8 @@ spec:
       serviceAccountName: storage-node-service-account
       containers:
       - name: storage-node-handler
-        image: simplyblock/storage-node-handler
+        image: "{{ .Values.image.storageNode.repository }}:{{ .Values.image.storageNode.tag }}"
+        imagePullPolicy: "Always"
         env:
         - name: SPDKCSI_SECRET
           valueFrom:

--- a/charts/latest/spdk-csi/templates/storage-node-handler.yaml
+++ b/charts/latest/spdk-csi/templates/storage-node-handler.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       - name: storage-node-handler
         image: "{{ .Values.image.storageNode.repository }}:{{ .Values.image.storageNode.tag }}"
-        imagePullPolicy: "Always"
+        imagePullPolicy: "{{ .Values.image.storageNode.pullPolicy }}"
         env:
         - name: SPDKCSI_SECRET
           valueFrom:

--- a/charts/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/latest/spdk-csi/templates/storage-node.yaml
@@ -96,7 +96,7 @@ spec:
     spec:
       serviceAccountName: storage-node-sa
       nodeSelector:
-        type: simplyblock-storage-plane
+        type: simplyblock-storage-plane-reserve
       volumes:
         - name: dev-vol
           hostPath:

--- a/charts/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/latest/spdk-csi/templates/storage-node.yaml
@@ -77,3 +77,50 @@ spec:
         volumeMounts:
         - name: dev-vol
           mountPath: /dev
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: storage-node-ds-reserve
+  annotations:
+    helm.sh/hook: post-install
+spec:
+  selector:
+    matchLabels:
+      app: storage-node-reserve
+  template:
+    metadata:
+      labels:
+        app: storage-node-reserve
+    spec:
+      serviceAccountName: storage-node-sa
+      nodeSelector:
+        type: simplyblock-storage-plane
+      volumes:
+        - name: dev-vol
+          hostPath:
+            path: /dev
+      hostNetwork: true
+      {{- if .Values.storagenode.tolerations.create }}
+      tolerations:
+      - effect: {{ .Values.storagenode.tolerations.effect }}
+        key: {{ .Values.storagenode.tolerations.key }}
+        operator: {{ .Values.storagenode.tolerations.operator }}
+        value: {{ .Values.storagenode.tolerations.value }}
+      {{- end }}
+      containers:
+      - name: s-node-api-container
+        image: "{{ .Values.image.simplyblock.repository }}:{{ .Values.image.simplyblock.tag }}"
+        imagePullPolicy: "Always"
+        command: ["python", "simplyblock_web/snode_app_k8s.py"]
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: dev-vol
+          mountPath: /dev

--- a/charts/latest/spdk-csi/templates/storage-node.yaml
+++ b/charts/latest/spdk-csi/templates/storage-node.yaml
@@ -112,7 +112,7 @@ spec:
       containers:
       - name: s-node-api-container
         image: "{{ .Values.image.simplyblock.repository }}:{{ .Values.image.simplyblock.tag }}"
-        imagePullPolicy: "Always"
+        imagePullPolicy: "{{ .Values.image.simplyblock.pullPolicy }}"
         command: ["python", "simplyblock_web/snode_app_k8s.py"]
         env:
         - name: HOSTNAME

--- a/charts/latest/spdk-csi/values.yaml
+++ b/charts/latest/spdk-csi/values.yaml
@@ -119,7 +119,7 @@ storagenode:
     value: simplyblock-storage-plane
   ifname: eth0
   cpuMask:
-  spdkImage:  
+  spdkImage:
   maxLvol: 10
   maxSnap: 10
   maxProv: 150g

--- a/charts/latest/spdk-csi/values.yaml
+++ b/charts/latest/spdk-csi/values.yaml
@@ -37,7 +37,14 @@ image:
     repository: simplyblock/simplyblock
     tag: release_v1
     pullPolicy: Always
-
+  storageNode:
+    repository: simplyblock/storage-node-handler
+    tag: latest
+    pullPolicy: Always
+  cachingNode:
+    repository: simplyblock/caching-node-handler
+    tag: latest
+    pullPolicy: Always
 serviceAccount:
   # Specifies whether a serviceAccount should be created
   create: true


### PR DESCRIPTION
Add a new Daemonset
1. To provision new pod with label `app=storage-node-reserve`
2. Controller picks up above pod for storage-node rescheduling