### PR TITLE
Grant ConfigMap management permissions in ClusterRole

### DIFF
--- a/charts/latest/spdk-csi/templates/handler-role.yaml
+++ b/charts/latest/spdk-csi/templates/handler-role.yaml
@@ -26,3 +26,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]


### PR DESCRIPTION
Updated ClusterRole to allow better management of ConfigMaps within the application.
